### PR TITLE
[codex] Fix Mesa sky shader undefined math

### DIFF
--- a/shaders/lib/optimizationFunctions.glsl
+++ b/shaders/lib/optimizationFunctions.glsl
@@ -1,26 +1,33 @@
+const float NORMALIZE_EPSILON = 1e-8;
+const float POW_EPSILON = 1e-6;
+
 vec2 normalize2(vec2 a) {
-    return a * inversesqrt(dot(a,a));
+    float len2 = dot(a,a);
+    return len2 > NORMALIZE_EPSILON ? a * inversesqrt(len2) : vec2(0.0);
 }
 vec3 normalize2(vec3 a) {
-    return a * inversesqrt(dot(a,a));
+    float len2 = dot(a,a);
+    return len2 > NORMALIZE_EPSILON ? a * inversesqrt(len2) : vec3(0.0);
 }
 vec4 normalize2(vec4 a) {
-    return a * inversesqrt(dot(a,a));
+    float len2 = dot(a,a);
+    return len2 > NORMALIZE_EPSILON ? a * inversesqrt(len2) : vec4(0.0);
 }
 
 mediump float pow2(float a, float b) {
-    return exp2(log2(a) * b);
+    if(a <= 0.0) return 0.0;
+    return pow(max(a, b < 0.0 ? POW_EPSILON : 0.0), b);
 }
 
 vec2 pow2(vec2 a, vec2 b) {
-    return exp2(log2(a) * b);
+    return vec2(pow2(a.x, b.x), pow2(a.y, b.y));
 }
 
 vec3 pow2(vec3 a, vec3 b) {
-    return exp2(log2(a) * b);
+    return vec3(pow2(a.x, b.x), pow2(a.y, b.y), pow2(a.z, b.z));
 }
 vec4 pow2(vec4 a, vec4 b) {
-    return exp2(log2(a) * b);
+    return vec4(pow2(a.x, b.x), pow2(a.y, b.y), pow2(a.z, b.z), pow2(a.w, b.w));
 }
 
 mediump float mix2(float a, float b, float c) {

--- a/shaders/lib/world/clouds.glsl
+++ b/shaders/lib/world/clouds.glsl
@@ -12,9 +12,13 @@
 #define CLOUD_TOP_BKG 1000.0
 #define STEP_SIZE_BKG (CLOUD_TOP_BKG - CLOUD_BASE_BKG)/CLOUD_STEPS_BKG
 
-vec4 lightCalc;
+vec4 lightCalc = vec4(0.0);
 
 float cloudCoverage;
+
+float safeRayY(vec3 rayDir) {
+    return rayDir.y >= 0.0 ? max(rayDir.y, 0.001) : min(rayDir.y, -0.001);
+}
 
 vec3 warp(vec3 uv) {
     float w1 = texture2D(noiseb, uv.xz * 0.5).x;
@@ -150,7 +154,7 @@ float getCloudShadow(vec3 rayOrigin, vec3 rayDir, vec3 sunDir, float cloudTime) 
 
     float shadow = 1.0;
 
-    float t = max((CLOUD_BASE - rayOrigin.y)/rayDir.y,0.0);
+    float t = max((CLOUD_BASE - rayOrigin.y)/safeRayY(rayDir),0.0);
     vec3 pos = rayOrigin + rayDir * t;
 
     // Convert world position into "skybox sampling space"
@@ -177,7 +181,7 @@ float getCloudShadow(vec3 rayOrigin, vec3 rayDir, vec3 sunDir, float cloudTime) 
 }
 
 vec4 renderVolumetricClouds(vec3 rayOrigin, vec3 rayDir, vec3 sunDir, float cloudTime) {
-    float t = max((CLOUD_BASE - rayOrigin.y)/rayDir.y,0.0);
+    float t = max((CLOUD_BASE - rayOrigin.y)/safeRayY(rayDir),0.0);
     vec3 pos = rayOrigin + rayDir * t;
 
     vec3 colorAcc = vec3(0.0);
@@ -267,7 +271,7 @@ vec4 renderVolumetricClouds(vec3 rayOrigin, vec3 rayDir, vec3 sunDir, float clou
 }
 
 vec4 renderBackgroundClouds(vec3 rayOrigin, vec3 rayDir, vec3 sunDir, float cloudTime) {
-    float t = max((CLOUD_BASE_BKG - rayOrigin.y)/rayDir.y,0.0);
+    float t = max((CLOUD_BASE_BKG - rayOrigin.y)/safeRayY(rayDir),0.0);
     vec3 pos = rayOrigin + rayDir * t;
 
     vec3 colorAcc = vec3(0.0);

--- a/shaders/program/composite2.glsl
+++ b/shaders/program/composite2.glsl
@@ -843,8 +843,9 @@
 
         vec4 pos = vec4(footPos, 1.0);
         vec3 rayDir = normalize2(pos.xyz);
+        float rayY = rayDir.y >= 0.0 ? max(rayDir.y, 0.001) : min(rayDir.y, -0.001);
 
-        vec2 uv = rayDir.xz*0.25/rayDir.y;
+        vec2 uv = rayDir.xz*0.25/rayY;
         //vec2 uv2 = pos.xz*0.001+worldTime*0.1;
 
         vec3 p = vec3(uv, 0);

--- a/shaders/program/gbuffers_skybasic.glsl
+++ b/shaders/program/gbuffers_skybasic.glsl
@@ -318,11 +318,11 @@
         outputColor = vec4(mix2(pow2(calcSkyColor(normalize(pos), currentColorA, currentColorB, noise),vec3(1/GAMMA)),vec3(0),blindness),1.0);
         mediump float sunMaxDistance = 0.135;
         mediump float distToSun = pow2(length((texCoord - sunScreenPos) * vec2(aspectRatio, 1.0)), 4.0);
-        float sunAngle = acos(dot(viewDir, sunDirection));
+        float sunAngle = acos(clamp(dot(viewDir, sunDirection), -1.0, 1.0));
         mediump float sunGradient = 1.0 - smoothstep(0.0, sunMaxDistance, sunAngle);
         mediump float moonMaxDistance = 0.08;
         mediump float distToMoon = length((moonScreenPos - texCoord) * vec2(aspectRatio, 1.0));
-        float moonAngle = acos(dot(viewDir, moonDirection));
+        float moonAngle = acos(clamp(dot(viewDir, moonDirection), -1.0, 1.0));
         mediump float moonGradient = 1.0 - smoothstep(0.0, moonMaxDistance, moonAngle);
         vec3 sunColor = vec3(1.0, 0.8, 0.7);
         vec3 sunColor2 = vec3(1.0, 0.7, 0.5);

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -200,7 +200,7 @@ customTexture.randnoisea = texture/RandomNoiseA_1.png
 customTexture.randnoiseb = texture/RandomNoiseA_2.png
 customTexture.randnoisec = texture/RandomNoiseA_3.png
 
-customTexture.randnoisergb = texture/RandomNoiseRGB.png
+customTexture.randnoisergb = texture/RandNoiseRGB.png
 
 #if LUT_NORM == 0
     customTexture.lutnormal = texture/lutNormal.png


### PR DESCRIPTION
## Summary

Fixes #7 by hardening shader math that can produce undefined values on AMD/Mesa/Linux drivers and correcting one case-sensitive texture path that only fails on Linux filesystems.

## Root Cause

The reported screenshots point at the sky/cloud composite path blowing out while world geometry remains mostly intact. The shader had several driver-sensitive undefined-value paths:

- `lightCalc` was read in `composite2` without being initialized.
- Cloud ray setup divided by `rayDir.y`, which can approach zero near the horizon.
- `normalize2()` used `inversesqrt(dot(a, a))` without guarding zero-length vectors.
- `pow2()` used `log2(a)` without guarding `a <= 0`.
- Sun/moon `acos(dot(...))` inputs were not clamped to `[-1, 1]`.

There was also a Linux-only resource path issue: `shaders.properties` referenced `texture/RandomNoiseRGB.png`, but the actual packed file is `texture/RandNoiseRGB.png`.

## Changes

- Initialize the cloud light accumulator.
- Guard cloud-ray horizon division.
- Make `normalize2()` and `pow2()` safer around undefined domains.
- Clamp sun/moon angle calculations before `acos()`.
- Correct the `randnoisergb` custom texture path casing.

## Validation

- Ran `git diff --check` and `git diff --cached --check` locally.
- I could not run a full Iris/Minecraft shader compile in this environment, so this should be tested on the Linux Mint + RX 7800 XT + Mesa setup from the issue before marking ready.